### PR TITLE
refactor: remove unused fullCategoryTree

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,4 @@
 let policies = [];
-let fullCategoryTree = {};
 
 document.addEventListener("DOMContentLoaded", () => {
   // 1. Sidebar-Resizer
@@ -61,7 +60,6 @@ document.addEventListener("DOMContentLoaded", () => {
     .then(res => res.json())
     .then(data => {
       policies = data;
-      fullCategoryTree = buildCategoryTree(policies);
       applyFilters();  // initial render
     })
     .catch(err => console.error("Fehler beim Laden der policies.json:", err));


### PR DESCRIPTION
## Summary
- remove unused fullCategoryTree variable and its initialization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e1faba988330aa148b6c9afe3055