### PR TITLE
Initialize category policy list once in buildCategoryTree

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,7 +85,8 @@ function buildCategoryTree(list) {
       node[cat] = node[cat] || {};
       node = node[cat];
     });
-    node.__policies = (node.__policies || []).concat(p);
+    if (!node.__policies) node.__policies = [];
+    node.__policies.push(p);
   });
   return tree;
 }


### PR DESCRIPTION
## Summary
- avoid re-creating policy arrays in `buildCategoryTree` by initializing `__policies` once and pushing entries

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e1f7242883309d9bae9295c41ed0