### PR TITLE
Remove inline handlers for copy buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -162,8 +162,7 @@ function showPolicy(p) {
       <tr>
         <td>Registry Path</td>
         <td class="copy-cell">${p.key || "-"}
-          <button class="copy-btn" title="Copy to clipboard"
-                  onclick="navigator.clipboard.writeText('${p.key || ""}')">
+          <button class="copy-btn" title="Copy to clipboard">
             <img src="copy-icon.png" alt="Copy"/>
           </button>
         </td>
@@ -171,8 +170,7 @@ function showPolicy(p) {
       <tr>
         <td>Registry Name</td>
         <td class="copy-cell">${p.valueName || "-"}
-          <button class="copy-btn" title="Copy to clipboard"
-                  onclick="navigator.clipboard.writeText('${p.valueName || ""}')">
+          <button class="copy-btn" title="Copy to clipboard">
             <img src="copy-icon.png" alt="Copy"/>
           </button>
         </td>
@@ -205,6 +203,18 @@ function showPolicy(p) {
   const explainDiv = `<div class="explain">${p.explainText || ""}</div>`;
   div.innerHTML = header + tbl + explainDiv;
   results.appendChild(div);
+
+  const [keyBtn, nameBtn] = div.querySelectorAll('.copy-btn');
+  if (keyBtn) {
+    keyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(p.key || "");
+    });
+  }
+  if (nameBtn) {
+    nameBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(p.valueName || "");
+    });
+  }
 
   // JSON view
   document.getElementById("jsonView").textContent = JSON.stringify(p, null, 2);


### PR DESCRIPTION
## Summary
- remove inline `onclick` attributes from policy detail template
- attach `addEventListener` handlers to copy buttons that write to clipboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e1f636bc8330b3669036316dac79