### PR TITLE
Allow layout to expand with content

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,8 +54,8 @@ header button {
 /* Layout */
 .layout {
   display: flex;
-  height: calc(100vh - 70px);
-  overflow: hidden;
+  min-height: calc(100vh - 70px);
+  overflow: visible;
 }
 
 .sidebar {
@@ -65,7 +65,6 @@ header button {
   background: #f4f4f4;
   border-right: 1px solid #ccc;
   padding: 1rem;
-  overflow-y: auto;
 }
 
 #resizer {


### PR DESCRIPTION
## Summary
- Let layout height grow with content by using `min-height` and visible overflow
- Remove sidebar's internal scrollbar so page length reflects expanded categories

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pip install selenium` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fa26ccb883308ddc3b7a1da5f760